### PR TITLE
Resolve IDE error by simplifying source set configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,18 +39,9 @@ subprojects {
         }
     }
 
-    sourceSets {
-        main {
-            java {
-                srcDirs = ['src/main']
-            }
-        }
-        test {
-            java {
-                srcDirs = ['src/test']
-            }
-        }
-    }
+    // Configure source directories explicitly to avoid IDE DSL resolution issues
+    sourceSets.main.java.srcDirs = ['src/main']
+    sourceSets.test.java.srcDirs = ['src/test']
 }
 
 // Helper to persist version changes


### PR DESCRIPTION
## Summary
- Simplify source set configuration to avoid closure resolution errors in IDEs.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1145d64c832f9e4663d6d4958335