### PR TITLE
Handle missing InputHandler gracefully

### DIFF
--- a/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
+++ b/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
@@ -141,5 +141,6 @@ public class Engine {
 
         gameLoop.cleanup();
         window.destroy();
+        InputHandler.dispose();
     }
 }

--- a/Engine/src/main/com/absolutephoenix/engine/input/InputHandler.java
+++ b/Engine/src/main/com/absolutephoenix/engine/input/InputHandler.java
@@ -1,6 +1,7 @@
 package com.absolutephoenix.engine.input;
 
 import org.lwjgl.glfw.GLFW;
+import java.util.Optional;
 
 /**
  * Central access point for keyboard, mouse and controller input.
@@ -20,9 +21,19 @@ public class InputHandler {
         GLFW.glfwSetScrollCallback(window, (w, xoff, yoff) -> mouse.handleScroll(xoff, yoff));
     }
 
-    /** Returns the singleton instance. */
-    public static InputHandler get() {
-        return instance;
+    /**
+     * Returns the singleton instance, if it has been initialized.
+     *
+     * @return an {@link Optional} containing the current instance or empty if
+     *         no handler has been created yet
+     */
+    public static Optional<InputHandler> get() {
+        return Optional.ofNullable(instance);
+    }
+
+    /** Resets the singleton instance. */
+    public static void dispose() {
+        instance = null;
     }
 
     /** Polls devices that require manual polling. */

--- a/Game/src/main/com/absolutephoenix/game/scenes/ExampleScene.java
+++ b/Game/src/main/com/absolutephoenix/game/scenes/ExampleScene.java
@@ -1,6 +1,7 @@
 package com.absolutephoenix.game.scenes;
 
 import com.absolutephoenix.engine.input.InputHandler;
+import java.util.Optional;
 import com.absolutephoenix.engine.rendering.SpriteBatch;
 import com.absolutephoenix.engine.rendering.Texture;
 import com.absolutephoenix.game.Scene;
@@ -28,7 +29,11 @@ public class ExampleScene implements Scene {
 
     @Override
     public void input() {
-        InputHandler input = InputHandler.get();
+        Optional<InputHandler> maybeInput = InputHandler.get();
+        if (maybeInput.isEmpty()) {
+            return;
+        }
+        InputHandler input = maybeInput.get();
         if (input.keyboard.keyPressed(GLFW.GLFW_KEY_SPACE)) {
             System.out.println("Space pressed");
         }


### PR DESCRIPTION
## Summary
- Replace `InputHandler.get()` with an `Optional`-based accessor
- Guard ExampleScene input logic when handler is uninitialized
- Add dispose hook and reset handler on engine shutdown

## Testing
- `gradle check`

------
https://chatgpt.com/codex/tasks/task_e_68ac5fa03808832f90634495ec580edc