### PR TITLE
Add basic engine input unit tests

### DIFF
--- a/Engine/build.gradle
+++ b/Engine/build.gradle
@@ -60,4 +60,11 @@ dependencies {
     implementation "org.joml:joml-primitives:${jomlPrimitivesVersion}"
     implementation "com.code-disaster.steamworks4j:steamworks4j:${steamworks4jVersion}"
     implementation "com.code-disaster.steamworks4j:steamworks4j-server:${steamworks4jServerVersion}"
+
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/Engine/src/test/com/absolutephoenix/engine/input/KeyboardTest.java
+++ b/Engine/src/test/com/absolutephoenix/engine/input/KeyboardTest.java
@@ -1,0 +1,43 @@
+package com.absolutephoenix.engine.input;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.glfw.GLFW;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeyboardTest {
+    @Test
+    void keyPressAndReleaseFlowWorks() {
+        Keyboard keyboard = new Keyboard();
+        int key = GLFW.GLFW_KEY_A;
+
+        // Initial state
+        assertFalse(keyboard.keyDown(key));
+        assertFalse(keyboard.keyPressed(key));
+        assertFalse(keyboard.keyReleased(key));
+
+        // Press key
+        keyboard.handle(key, GLFW.GLFW_PRESS);
+        assertTrue(keyboard.keyDown(key));
+        assertTrue(keyboard.keyPressed(key));
+        assertFalse(keyboard.keyReleased(key));
+
+        // Advance frame
+        keyboard.update();
+        assertTrue(keyboard.keyDown(key));
+        assertFalse(keyboard.keyPressed(key));
+        assertFalse(keyboard.keyReleased(key));
+
+        // Release key
+        keyboard.handle(key, GLFW.GLFW_RELEASE);
+        assertFalse(keyboard.keyDown(key));
+        assertFalse(keyboard.keyPressed(key));
+        assertTrue(keyboard.keyReleased(key));
+
+        // Final update
+        keyboard.update();
+        assertFalse(keyboard.keyDown(key));
+        assertFalse(keyboard.keyPressed(key));
+        assertFalse(keyboard.keyReleased(key));
+    }
+}

--- a/Engine/src/test/com/absolutephoenix/engine/input/MappingRegistryTest.java
+++ b/Engine/src/test/com/absolutephoenix/engine/input/MappingRegistryTest.java
@@ -1,0 +1,26 @@
+package com.absolutephoenix.engine.input;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MappingRegistryTest {
+    @Test
+    void defaultMappingResolvesDualSenseTrackpad() {
+        Integer idx = MappingRegistry.resolve("id1", "dualsense wireless controller", MappingRegistry.Logical.PS_TRACKPAD);
+        assertEquals(13, idx);
+    }
+
+    @Test
+    void learnedMappingOverridesDefault() {
+        String key = "id2";
+        MappingRegistry.learn(key, MappingRegistry.Logical.PS_TRACKPAD, 5);
+        Integer idx = MappingRegistry.resolve(key, "dualsense", MappingRegistry.Logical.PS_TRACKPAD);
+        assertEquals(5, idx);
+    }
+
+    @Test
+    void resolveReturnsNullForUnknownControl() {
+        Integer idx = MappingRegistry.resolve("id3", "unknown controller", MappingRegistry.Logical.PS_MUTE);
+        assertNull(idx);
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 to Engine module
- test controller mapping registry defaults and learning
- test keyboard state transitions

## Testing
- `gradle test`
- `gradle check`


------
https://chatgpt.com/codex/tasks/task_e_68ac66a65238832fa21c2900ae233e1d