### PR TITLE
Use Java 21 toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(23)
+            languageVersion = JavaLanguageVersion.of(21)
         }
     }
 


### PR DESCRIPTION
## Summary
- target Java 21 LTS in Gradle toolchain for subprojects

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ac72f9d2a0832fa2614dcb3caf6a91