### PR TITLE
Ensure logger resources are released on shutdown

### DIFF
--- a/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
+++ b/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
@@ -1,6 +1,7 @@
 package com.absolutephoenix.engine.core;
 
 import com.absolutephoenix.engine.input.InputHandler;
+import com.absolutephoenix.engine.logging.Logger;
 import com.absolutephoenix.engine.window.Window;
 
 import static org.lwjgl.glfw.GLFW.glfwWaitEventsTimeout;
@@ -142,5 +143,6 @@ public class Engine {
         gameLoop.cleanup();
         window.destroy();
         InputHandler.dispose();
+        Logger.close();
     }
 }

--- a/Engine/src/main/com/absolutephoenix/engine/logging/Logger.java
+++ b/Engine/src/main/com/absolutephoenix/engine/logging/Logger.java
@@ -80,6 +80,19 @@ public final class Logger {
         }
     }
 
+    public static void close() {
+        if (writer != null) {
+            try {
+                writer.flush();
+                writer.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            writer = null;
+        }
+        initialized = false;
+    }
+
     private static boolean shouldLog(LogLevel level) {
         return level.getPriority() >= currentLevel.getPriority() && level != LogLevel.OFF && currentLevel != LogLevel.OFF;
     }


### PR DESCRIPTION
## Summary
- add `Logger.close()` to flush and close the log file writer
- invoke `Logger.close()` after disposing input in `Engine`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68acd3751c5c832fb29424684e09b6e4