### PR TITLE
Ensure InputHandler thread safety and cleanup

### DIFF
--- a/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
+++ b/Engine/src/main/com/absolutephoenix/engine/core/Engine.java
@@ -141,6 +141,7 @@ public class Engine {
         }
 
         gameLoop.cleanup();
+        input.close();
         window.destroy();
         InputHandler.dispose();
         Logger.close();

--- a/Engine/src/main/com/absolutephoenix/engine/input/InputHandler.java
+++ b/Engine/src/main/com/absolutephoenix/engine/input/InputHandler.java
@@ -1,19 +1,26 @@
 package com.absolutephoenix.engine.input;
 
 import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWCursorPosCallback;
+import org.lwjgl.glfw.GLFWKeyCallback;
+import org.lwjgl.glfw.GLFWMouseButtonCallback;
+import org.lwjgl.glfw.GLFWScrollCallback;
 import java.util.Optional;
 
 /**
  * Central access point for keyboard, mouse and controller input.
  */
 public class InputHandler {
-    private static InputHandler instance;
+    private static volatile InputHandler instance;
+
+    private final long window;
 
     public final Keyboard keyboard = new Keyboard();
     public final Mouse mouse = new Mouse();
     public final Controller controller = new Controller();
 
     public InputHandler(long window) {
+        this.window = window;
         instance = this;
         GLFW.glfwSetKeyCallback(window, (w, key, scancode, action, mods) -> keyboard.handle(key, action));
         GLFW.glfwSetMouseButtonCallback(window, (w, button, action, mods) -> mouse.handleButton(button, action));
@@ -28,12 +35,30 @@ public class InputHandler {
      *         no handler has been created yet
      */
     public static Optional<InputHandler> get() {
-        return Optional.ofNullable(instance);
+        synchronized (InputHandler.class) {
+            return Optional.ofNullable(instance);
+        }
     }
 
     /** Resets the singleton instance. */
     public static void dispose() {
-        instance = null;
+        synchronized (InputHandler.class) {
+            instance = null;
+        }
+    }
+
+    /**
+     * Removes GLFW callbacks and frees the associated resources.
+     */
+    public void close() {
+        GLFWKeyCallback keyCb = GLFW.glfwSetKeyCallback(window, null);
+        if (keyCb != null) keyCb.free();
+        GLFWMouseButtonCallback mouseBtnCb = GLFW.glfwSetMouseButtonCallback(window, null);
+        if (mouseBtnCb != null) mouseBtnCb.free();
+        GLFWCursorPosCallback cursorPosCb = GLFW.glfwSetCursorPosCallback(window, null);
+        if (cursorPosCb != null) cursorPosCb.free();
+        GLFWScrollCallback scrollCb = GLFW.glfwSetScrollCallback(window, null);
+        if (scrollCb != null) scrollCb.free();
     }
 
     /** Polls devices that require manual polling. */


### PR DESCRIPTION
## Summary
- keep reference to GLFW window handle and remove callbacks via new close()
- make InputHandler singleton volatile and synchronize access
- close InputHandler during engine shutdown

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68acd55444c8832fa7381c1cdf256462