### PR TITLE
Reset active texture after sprite batch flush

### DIFF
--- a/Engine/src/main/com/absolutephoenix/engine/rendering/SpriteBatch.java
+++ b/Engine/src/main/com/absolutephoenix/engine/rendering/SpriteBatch.java
@@ -123,6 +123,7 @@ public class SpriteBatch {
         GL11.glDrawElements(GL11.GL_TRIANGLES, sprites * 6, GL11.GL_UNSIGNED_INT, 0);
         GL30.glBindVertexArray(0);
         shader.unbind();
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0);
         buffer.clear();
         sprites = 0;
     }


### PR DESCRIPTION
## Summary
- Unbind the active texture when flushing `SpriteBatch` to avoid leaking texture state.
- Verified no call sites relied on textures remaining bound after flush.

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68acd8f94ca8832f8651984d1ecae7fa